### PR TITLE
util: use effective user id on BSDs

### DIFF
--- a/pkg/util/capabilities_bsd.go
+++ b/pkg/util/capabilities_bsd.go
@@ -7,5 +7,5 @@ import (
 )
 
 func HasAdminPrivileges() bool {
-	return os.Getuid() == 0
+	return os.Geteuid() == 0
 }


### PR DESCRIPTION
See also #120 